### PR TITLE
fix: Fix URL construction losing base path components

### DIFF
--- a/Source/Core/APIClient.swift
+++ b/Source/Core/APIClient.swift
@@ -175,25 +175,20 @@ public struct APIClient: Sendable {
     /// - Returns: The fully constructed URL for the request
     /// - Throws: `NetworkError.invalidURL` if the URL cannot be constructed
     private func constructURL(from specification: APISpecification) throws(NetworkError) -> URL {
-        guard let baseWithEndpoint = URL(string: specification.endpoint, relativeTo: baseURL) else {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true) else {
             throw NetworkError.invalidURL
         }
         
-        if let queryParameters = specification.queryParameters, !queryParameters.isEmpty {
-            guard var components = URLComponents(url: baseWithEndpoint, resolvingAgainstBaseURL: true) else {
-                throw NetworkError.invalidURL
-            }
-            
-            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
-            
-            guard let finalURL = components.url else {
-                throw NetworkError.invalidURL
-            }
-            
-            return finalURL
-        }
+        components.path += specification.endpoint
         
-        return baseWithEndpoint
+        if let queryParameters = specification.queryParameters, !queryParameters.isEmpty {
+            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        guard let finalURL = components.url else {
+            throw NetworkError.invalidURL
+        }
+
+        return finalURL
     }
 
     /// Validates the HTTP response status and type.


### PR DESCRIPTION
This pull request refactors the `constructURL` function in the `APIClient` struct to improve readability and flexibility when constructing URLs. The key change involves replacing the use of `URL(string:relativeTo:)` with `URLComponents` for more structured URL manipulation.

### Refactor to URL construction logic:
* [`Source/Core/APIClient.swift`](diffhunk://#diff-e0c26e7dfd034939e7720db8d01bc844df455a399a9168f625f2634f9ffe7a3cL178-L198): Replaced the use of `URL(string:relativeTo:)` with `URLComponents` for constructing URLs. This change allows for more explicit handling of the URL path and query parameters, improving clarity and reducing potential errors.